### PR TITLE
Added jiralert docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/prometheus/busybox:latest
+
+COPY jiralert /bin/jiralert
+
+ENTRYPOINT [ "/bin/jiralert" ]
+


### PR DESCRIPTION
Hi :wave:  

Docker image is must-have nowadays, so might be handy to have Dockerfile inside repo itself as [Thanos](https://github.com/improbable-eng/thanos) and Prometheus projects have. 

I would suggest setting (at later date) some docker push command to your preferred public docker registry for ease of use like here: https://github.com/improbable-eng/thanos/blob/master/Makefile#L104

In the meantime the image is available here: https://hub.docker.com/r/bplotka/jiralert/tags

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>