### PR TITLE
Remove -ignore flag from Makefile, fix log.level info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ RELEASE     := jiralert-$(VERSION).linux-amd64
 RELEASE_DIR := release/$(RELEASE)
 
 PACKAGES           := $(shell $(GO) list ./... | grep -v /vendor/)
-STATICCHECK_IGNORE :=
 DOCKER_IMAGE_NAME  := jiralert
 
 # v1.2.0
@@ -29,7 +28,7 @@ format:
 
 check: $(STATICCHECK)
 	@echo ">> running staticcheck"
-	@$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(PACKAGES)
+	@$(STATICCHECK) $(PACKAGES)
 
 build:
 	@echo ">> building binaries"

--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -153,8 +153,6 @@ func setupLogger(lvl string, fmt string) (logger log.Logger) {
 		filter = level.AllowWarn()
 	case "debug":
 		filter = level.AllowDebug()
-	case "info":
-		fallthrough
 	default:
 		filter = level.AllowInfo()
 	}

--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -154,6 +154,7 @@ func setupLogger(lvl string, fmt string) (logger log.Logger) {
 	case "debug":
 		filter = level.AllowDebug()
 	case "info":
+		fallthrough
 	default:
 		filter = level.AllowInfo()
 	}


### PR DESCRIPTION
staticcheck no longer supports -ignore flag since release 2019.1

See:
http://staticcheck.io/changes/2019.1
https://staticcheck.io/docs/#ignoring-problems


Also fixed segfaults if log.level was set empty or `info`.